### PR TITLE
Make it possible to update the index after updating a blog entry

### DIFF
--- a/chat_hatenablog/entry.py
+++ b/chat_hatenablog/entry.py
@@ -1,0 +1,5 @@
+class Entry:
+    def __init__(self, title, body, basename):
+        self.title = title
+        self.body = body
+        self.basename = basename

--- a/chat_hatenablog/entry.py
+++ b/chat_hatenablog/entry.py
@@ -1,5 +1,11 @@
+import hashlib
+
+
 class Entry:
     def __init__(self, title, body, basename):
         self.title = title
         self.body = body
         self.basename = basename
+
+    def content_hash(self):
+        return hashlib.sha256(self.body.encode('utf-8')).hexdigest()

--- a/chat_hatenablog/vector_store.py
+++ b/chat_hatenablog/vector_store.py
@@ -74,8 +74,14 @@ class VectorStore:
 
     def get_sorted(self, query):
         q = np.array(create_embeddings(query))
+        items = [
+            [info['title'], embeddings_list['body'], basename,
+                embeddings_list['embeddings']]
+            for basename, info in self.cache.items()
+            for embeddings_list in info.get('embeddings_list')
+        ]
         buf = []
-        for body, (v, title, basename) in self.cache.items():
-            buf.append((q.dot(v), body, title, basename))
+        for title, body, basename, embeddings in items:
+            buf.append((q.dot(embeddings), body, title, basename))
         buf.sort(reverse=True)
         return buf

--- a/tests/test_entry.py
+++ b/tests/test_entry.py
@@ -1,0 +1,14 @@
+from chat_hatenablog.entry import Entry
+
+
+def test_entry_init():
+    entry = Entry("Test Title", "Test Body", "test-basename")
+    assert entry.title == "Test Title"
+    assert entry.body == "Test Body"
+    assert entry.basename == "test-basename"
+
+
+def test_entry_content_hash():
+    entry = Entry("Test Title", "Test Body", "test-basename")
+    assert entry.content_hash(
+    ) == 'ae6d8a1c07f438667618879eae74ffab84c236ea5d8ca52d5ca0523cc35e8bb9'

--- a/tests/test_vector_store.py
+++ b/tests/test_vector_store.py
@@ -84,3 +84,39 @@ class TestVectorStore:
                 }]
             },
         }, "the first entry should be updated"
+
+    @patch('chat_hatenablog.vector_store.create_embeddings')
+    def test_get_sorted(self, mock_create_embeddings):
+        vector_store = VectorStore("./test_index.pkl")
+
+        vector_store.cache = {
+            "test_basename1": {
+                "content_hash": 'dummy_hash1',
+                "title": "test title1",
+                "embeddings_list": [
+                    {
+                        "body": "test body1",
+                        "embeddings": [0.1, 0.1]
+                    },
+                    {
+                        "body": "updated",
+                        "embeddings": [0.2, 0.2]
+                    }
+                ]
+            },
+            "test_basename2": {
+                "content_hash": 'dummy_hash2',
+                "title": "test title2",
+                "embeddings_list": [{
+                    "body": "test body2",
+                    "embeddings": [0.5, 0.5]
+                }]
+            },
+        }
+
+        mock_create_embeddings.return_value = [0.2, 0.2]
+        assert vector_store.get_sorted('query1') == [
+            (0.2, 'test body2', 'test title2', 'test_basename2'),
+            (0.08000000000000002, 'updated', 'test title1', 'test_basename1'),
+            (0.04000000000000001, 'test body1', 'test title1', 'test_basename1'),
+        ]

--- a/tests/test_vector_store.py
+++ b/tests/test_vector_store.py
@@ -1,6 +1,12 @@
 import pytest
 from unittest.mock import patch
+from chat_hatenablog.entry import Entry
 from chat_hatenablog.vector_store import VectorStore, create_embeddings
+
+
+class MockMarkdownTextSplitter:
+    def split_text(self, text):
+        return text.split(",")
 
 
 class TestVectorStore:
@@ -10,23 +16,71 @@ class TestVectorStore:
         assert vector_store.cache == {}
 
     @patch('chat_hatenablog.vector_store.create_embeddings')
-    def test_add_record_new(self, mock_create_embeddings):
-        mock_create_embeddings.return_value = [0.5, 0.5, 0.5]
-
+    def test_add_entry(self, mock_create_embeddings):
         vector_store = VectorStore("./test_index.pkl")
+        vector_store.markdown_splitter = MockMarkdownTextSplitter()
 
-        body, title, basename = "test body", "test title", "test_basename"
-        vector_store.add_record(body, title, basename)
-        mock_create_embeddings.assert_called_with(body)
+        mock_create_embeddings.return_value = [0.5, 0.5]
+        entry1 = Entry("test title1", "test body1", "test_basename1")
+        vector_store.add_entry(entry1)
         assert vector_store.cache == {
-            body: ([0.5, 0.5, 0.5], title, basename)
-        }, "the first record should be added"
+            "test_basename1": {
+                "content_hash": entry1.content_hash(),
+                "title": "test title1",
+                "embeddings_list": [{
+                    "body": "test body1",
+                    "embeddings": [0.5, 0.5]
+                }]
+            }
+        }, "the first entry should be added"
 
-        mock_create_embeddings.return_value = [0.2, 0.2, 0.2]
-        body2, title2, basename2 = "test body2", "test title2", "test_basename2"
-        vector_store.add_record(body2, title2, basename2)
-        mock_create_embeddings.assert_called_with(body2)
+        mock_create_embeddings.return_value = [0.3, 0.3]
+        entry2 = Entry("test title2", "test body2", "test_basename2")
+        vector_store.add_entry(entry2)
         assert vector_store.cache == {
-            body: ([0.5, 0.5, 0.5], title, basename),
-            body2: ([0.2, 0.2, 0.2], title2, basename2)
-        }, "the second record should be added"
+            "test_basename1": {
+                "content_hash": entry1.content_hash(),
+                "title": "test title1",
+                "embeddings_list": [{
+                    "body": "test body1",
+                    "embeddings": [0.5, 0.5]
+                }]
+            },
+            "test_basename2": {
+                "content_hash": entry2.content_hash(),
+                "title": "test title2",
+                "embeddings_list": [{
+                    "body": "test body2",
+                    "embeddings": [0.3, 0.3]
+                }]
+            },
+        }, "the second entry should be added"
+
+        mock_create_embeddings.return_value = [0.2, 0.2]
+        updated_entry1 = Entry(
+            "test title1", "test body1,updated", "test_basename1")
+        vector_store.add_entry(updated_entry1)
+        assert vector_store.cache == {
+            "test_basename1": {
+                "content_hash": updated_entry1.content_hash(),
+                "title": "test title1",
+                "embeddings_list": [
+                    {
+                        "body": "test body1",
+                        "embeddings": [0.2, 0.2]
+                    },
+                    {
+                        "body": "updated",
+                        "embeddings": [0.2, 0.2]
+                    }
+                ]
+            },
+            "test_basename2": {
+                "content_hash": entry2.content_hash(),
+                "title": "test title2",
+                "embeddings_list": [{
+                    "body": "test body2",
+                    "embeddings": [0.3, 0.3]
+                }]
+            },
+        }, "the first entry should be updated"


### PR DESCRIPTION
Closes: #5 

Before this pull request, the index includes duplicated body when an entry was edited.  This is because an index is body based and doesn't have updating system.

I fix the index structure to only update an updated entry.  The index structure is as follows:
```
    {
        "basename1": {
            "content_hash": "...",
            "title": "title1",
            "embeddings_list": [
                {"body": ..., "embeddings": [...]},
                {"body": ..., "embeddings": [...]},
            ],
        },
        "basename2": { ... },
    }
```