### PR TITLE
Avoid saving when indices are not changed

### DIFF
--- a/chat_hatenablog/vector_store.py
+++ b/chat_hatenablog/vector_store.py
@@ -49,6 +49,9 @@ class VectorStore:
         self.markdown_splitter = MarkdownTextSplitter(
             chunk_size=1000, chunk_overlap=0)
 
+        # To avoid saving the cache file when nothing is changed
+        self._dirty_flag = False
+
     def add_entry(self, entry):
         # Skip if the entry is not changed
         existing_entry_data = self.cache.get(entry.basename)
@@ -69,8 +72,12 @@ class VectorStore:
             })
             time.sleep(0.2)
 
+        self._dirty_flag = True
+
     def save(self):
-        pickle.dump(self.cache, open(self.index_file, "wb"))
+        if self._dirty_flag:
+            pickle.dump(self.cache, open(self.index_file, "wb"))
+            self._dirty_flag = False
 
     def get_sorted(self, query):
         q = np.array(create_embeddings(query))


### PR DESCRIPTION
Closes: https://github.com/shibayu36/chat-hatenablog/issues/4

At present, VectorStore saves an index every time `save` is called.  It's the reason that `./chat-hatenablog make-index` command is slow when updating index again.

This PullRequest introduces dirty_flag to avoid unnecessary saving an index to file.