### PR TITLE
Use ~/.chat-hatenablog/ for the default index path

### DIFF
--- a/chat-hatenablog
+++ b/chat-hatenablog
@@ -10,6 +10,12 @@ dotenv.load_dotenv()
 openai.api_key = os.getenv("OPENAI_API_KEY")
 
 
+def default_index_file_path() -> str:
+    home_dir = os.path.expanduser('~')
+    tool_dir = os.path.join(home_dir, '.chat-hatenablog')
+    return os.path.join(tool_dir, 'index.pickle')
+
+
 def main():
     parser = argparse.ArgumentParser(
         description='Chat HatenaBlog')
@@ -20,13 +26,17 @@ def main():
     subparsers = parser.add_subparsers(
         title='subcommands', description='available subcommands')
 
+    index_file_args = {
+        "default": default_index_file_path(),
+        "help": "Index file path. Default: ~/.chat-hatenablog/index.pickle"
+    }
+
     # ask subcommand
     parser_ask = subparsers.add_parser(
         'ask', description='Ask a question and get answers from your Hatena Blog')
     parser_ask.add_argument("--query", required=True)
     parser_ask.add_argument(
-        "--index-file", default="indices/index.pickle",
-        help="Index file path")
+        "--index-file", **index_file_args)
     parser_ask.add_argument(
         "--base-url", default=os.environ.get("BASE_URL", ""),
         help="Base URL of the blog. (e.g. https://example.com/.)  You can set this value with BASE_URL environment variable.")
@@ -39,8 +49,7 @@ def main():
         "--mt-file", required=True,
         help="MT exported file path")
     parser_make_index.add_argument(
-        "--index-file", default="indices/index.pickle",
-        help="Index file path")
+        "--index-file", **index_file_args)
     parser_make_index.set_defaults(func=make_index)
 
     args = parser.parse_args()


### PR DESCRIPTION
I will make this repository able to be installed by `pip install`.  After that, using the current directory as the place for a default index will be unsuitable.

I will use ~/.chat-hatenablog/ for the default index directory so that we can use this tool anywhere.